### PR TITLE
fix: send client sdk type header

### DIFF
--- a/src/base_client.rs
+++ b/src/base_client.rs
@@ -791,6 +791,7 @@ where
                 let mut headers = HashMap::new();
 
                 headers.insert("Client-Sdk-Version".to_string(), "1.0.0".to_string());
+                headers.insert("Client-Sdk-Type".to_string(), "typescript".to_string());
                 headers.insert("Content-Type".to_string(), "application/json".to_string());
 
                 let url = format!("{}/v1/fetch_key", base_url);


### PR DESCRIPTION
## Summary
- send Client-Sdk-Type: typescript on /v1/fetch_key requests
- keep the existing SDK version and content type headers

## Verification
- cargo fmt --check
- cargo check